### PR TITLE
use call path for command line arguments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,7 @@ TerrainTypes(const argh::parser& cmdl) {
     std::string biome_name;
 
     cmdl("biome-name", "-") >> biome_name;
-    std::filesystem::path biome_data_file = biome_name;
+    std::filesystem::path biome_data_file = files::get_argument_path(biome_name);
     biome_data_file += ".json";
     auto biome_file = files::open_data_file(biome_data_file);
     if (biome_file.has_value())
@@ -97,7 +97,7 @@ TerrainTypes(const argh::parser& cmdl) {
 
     Json::Value materials_json;
     cmdl("materials", "-") >> material_file;
-    std::filesystem::path material_data_file = material_file;
+    std::filesystem::path material_data_file = files::get_argument_path(material_file);
     material_data_file += ".json";
     auto materials_file = files::open_data_file(material_data_file);
     if (materials_file.has_value())
@@ -125,7 +125,7 @@ GenerateTerrain(const argh::parser& cmdl) {
     cmdl("size", 6) >> size;
     World world("base", size, size);
 
-    std::string path_out = cmdl(2).str();
+    std::filesystem::path path_out = files::get_argument_path(cmdl(2).str());
 
     world.qb_save(path_out);
 
@@ -166,11 +166,10 @@ image_test(const argh::parser& cmdl) {
         return result;
 
     } else {
-        std::string path_in = cmdl(2).str();
-        std::filesystem::path lua_file_path = files::get_root_path() / path_in;
+        std::filesystem::path lua_file_path = files::get_argument_path(cmdl(2).str());
 
-        std::string path_out = cmdl(3).str();
-        std::filesystem::path png_path = files::get_root_path() / path_out;
+        std::filesystem::path png_path = files::get_argument_path(cmdl(3).str());
+
         size_t size;
         cmdl("size", 6) >> size;
 
@@ -250,8 +249,10 @@ NoiseTest() {
 
 int
 save_test(const argh::parser& cmdl) {
-    std::string path_in = cmdl(2).str();
-    std::string path_out = cmdl(3).str();
+    std::filesystem::path path_in = files::get_argument_path(cmdl(2).str());
+
+    std::filesystem::path path_out = files::get_argument_path(cmdl(3).str());
+
     size_t seed;
     cmdl("seed", SEED) >> seed;
     World world("base", path_in, seed);
@@ -263,8 +264,9 @@ save_test(const argh::parser& cmdl) {
 
 int
 path_finder_test(const argh::parser& cmdl) {
-    std::string path_in = cmdl(2).str();
-    std::string path_out = cmdl(3).str();
+    std::filesystem::path path_in = files::get_argument_path(cmdl(2).str());
+
+    std::filesystem::path path_out = files::get_argument_path(cmdl(3).str());
     quill::Logger* logger = logging::main_logger;
 
     size_t seed;
@@ -342,7 +344,7 @@ StressTest(const argh::parser& cmdl) {
 
 int
 opengl_entry(const argh::parser& cmdl) {
-    std::string path_in = cmdl(2).str();
+    std::filesystem::path path_in = files::get_argument_path(cmdl(2).str());
 
     size_t seed;
     cmdl("seed", SEED) >> seed;
@@ -374,8 +376,8 @@ LogTest() {
     );
 
     LOG_INFO(
-        logging::lua_logger,
-        "[{}.lua:{}] - This is what a lua log should look like.", "example_file", 37
+        logging::lua_logger, "[{}.lua:{}] - This is what a lua log should look like.",
+        "example_file", 37
     );
 
     return 0;

--- a/src/util/files.hpp
+++ b/src/util/files.hpp
@@ -48,4 +48,14 @@ open_resource_file(std::filesystem::path path) {
     return open_file(get_resources_path() / path);
 }
 
+inline std::filesystem::path
+get_argument_path(std::filesystem::path path) {
+    if (path.is_absolute()){
+        return path;
+    }
+    else {
+        return std::filesystem::current_path() / path;
+    }
+}
+
 } // namespace files

--- a/src/util/files.hpp
+++ b/src/util/files.hpp
@@ -48,12 +48,22 @@ open_resource_file(std::filesystem::path path) {
     return open_file(get_resources_path() / path);
 }
 
+/**
+ * @brief Get full path of path passed as command line argument.
+ * 
+ * @param std::filesystem::path path given as command line argument.
+ * 
+ * @return `std::filesystem::path` full path
+ */
 inline std::filesystem::path
 get_argument_path(std::filesystem::path path) {
     if (path.is_absolute()){
         return path;
     }
     else {
+        // yes I know this can be unsafe as current path can change
+        // we could save it as a static variable in some function
+        // but it probably won't change
         return std::filesystem::current_path() / path;
     }
 }


### PR DESCRIPTION
When command line arguments are given use path relative to where command was called.