### PR TITLE
Test opengl backend

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,6 +71,7 @@ jobs:
           cmake --build .
 
       - name: Test
-        run: |
-          cd build
-          ninja test
+        uses: coactions/setup-xvfb@v1
+        with:
+            run: ninja test
+            working-directory: ./build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,4 +144,4 @@ add_test(NAME LuaLogging COMMAND FunGame Test Lua Logging)
 add_test(NAME LuaLoadTime COMMAND FunGame Test Lua LoadTime)
 add_test(NAME LuaLoadScript COMMAND FunGame Test Lua LoadScript)
 add_test(NAME LuaTransferScript COMMAND FunGame Test Lua TransferScript)
-
+add_test(NAME EngineTest COMMAND FunGame Test EngineTest)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -465,8 +465,7 @@ tests(const argh::parser& cmdl) {
     } else if (run_function == "LoadManifest") {
         manifest::ObjectHandler object_handler;
         return object_handler.load_all_manifests<false>();
-
-    } else if (run_function == "EnginTest") {
+    } else if (run_function == "EngineTest") {
         return gui::opengl_tests();
     } else if (run_function == "Lua") {
         return lua_tests(cmdl);


### PR DESCRIPTION
This adds xvfb to the GitHub action. This means that opengl can be tested headless.

https://github.com/coactions/setup-xvfb