### PR TITLE
remove optimize 3 from clang

### DIFF
--- a/src/gui/render/gpu_data/vertex_buffer_object.hpp
+++ b/src/gui/render/gpu_data/vertex_buffer_object.hpp
@@ -568,7 +568,10 @@ VertexBufferObject<T, Buffer>::bind() const {
 }
 
 template <class T, BindingTarget Buffer>
-__attribute__((optimize(3))) void
+#ifdef GCC
+__attribute__((optimize(3)))
+#endif
+void
 VertexBufferObject<T, Buffer>::attach_to_vertex_attribute(GLuint index) const {
     static_assert(
         Buffer != BindingTarget::ELEMENT_ARRAY_BUFFER,


### PR DESCRIPTION
Optimize started throwing errors on clang 19. This should fix that.

There is some concern about this not being implemented, but the only concern is that debug builds will be slower on clang. As I don't use clang to debug this won't be a problem. The release build should be unaffected. 